### PR TITLE
Update GitHub's RSA fingerprint after the key leak

### DIFF
--- a/articles/machine-learning/concept-train-model-git-integration.md
+++ b/articles/machine-learning/concept-train-model-git-integration.md
@@ -111,7 +111,7 @@ You will see a response like:
 
 ```bash
 The authenticity of host 'example.com (192.30.255.112)' can't be established.
-RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
+RSA key fingerprint is SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s.
 Are you sure you want to continue connecting (yes/no)? yes
 Warning: Permanently added 'github.com,192.30.255.112' (RSA) to the list of known hosts.
 ```


### PR DESCRIPTION
After a recent key leak GitHub has rotated its RSA key, so the fingerprint has changed as well. We shouldn't be advertising the revoked one's as acceptable.

- New keys: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints.
- Related article: https://www.bleepingcomputer.com/news/security/githubcom-rotates-its-exposed-private-ssh-key/